### PR TITLE
fix: prevent duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -176,7 +176,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid registering multiple toast listeners by running effect once

## Testing
- `pnpm lint` (fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a06708cc1883218d7d1b8eec59ec29