### PR TITLE
Use ReturnType for interval ref in WelcomeModal

### DIFF
--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -9,7 +9,7 @@ interface WelcomeModalProps {
 const WelcomeModal: React.FC<WelcomeModalProps> = ({ onProceed }) => {
   const [progress, setProgress] = useState(0);
   const [fadeOut, setFadeOut] = useState(false);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Gestione avanzamento progress bar e chiusura automatica
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix `intervalRef` type to use `ReturnType<typeof setInterval>`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0682c48ac8321918fc8434ec657bd