### PR TITLE
fix: update lunch break warning message

### DIFF
--- a/src/components/WorkTimeTracker.tsx
+++ b/src/components/WorkTimeTracker.tsx
@@ -351,7 +351,7 @@ const WorkTimeTracker = () => {
 
       {showPausaMinimaMsg && (
         <div className="mb-4 p-2 bg-blue-100 text-blue-900 rounded text-sm font-semibold">
-          Hai fatto una pausa pranzo di meno di 30 min ma questi verranno conteggiati lo stesso
+          Hai fatto una pausa pranzo inferiore a 30 min, ma verrà conteggiata comunque
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- update lunch break warning message

## Testing
- `pnpm lint` (fails: An interface declaring no members is equivalent to its supertype)


------
https://chatgpt.com/codex/tasks/task_e_68a06827cfd0832184867c93a1ba801c