### PR TITLE
chore: update instrumentation test package name

### DIFF
--- a/android/app/src/androidTest/java/com/getcapacitor/myapp/ExampleInstrumentedTest.java
+++ b/android/app/src/androidTest/java/com/getcapacitor/myapp/ExampleInstrumentedTest.java
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        assertEquals("com.getcapacitor.app", appContext.getPackageName());
+        assertEquals("com.example.radiantkookaburraswim", appContext.getPackageName());
     }
 }


### PR DESCRIPTION
## Summary
- ensure ExampleInstrumentedTest uses the new app package ID

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" when running wrapper)*
- `gradle test` *(fails: Could not read script '/workspace/torna_a_casa/android/capacitor.settings.gradle' as it does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a06830e3508321948fa64458a89f4f