### PR TITLE
Add GitHub Action to build Android release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,56 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web assets
+        run: pnpm build
+
+      - name: Sync Capacitor
+        run: npx cap sync android
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x android/gradlew
+
+      - name: Build Android release
+        working-directory: android
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: android/app/build/outputs/apk/release/*.apk
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: android/app/build/outputs/apk/release/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ L'app calcola gli orari di lavoro, le pause pranzo e gestisce i permessi dei dip
 
 I componenti principali si trovano nella cartella `src/`: i componenti React sono in `src/components` e le pagine in `src/pages`.
 
+## Release Android
+
+Il repository include una GitHub Action per creare automaticamente l'APK di release.
+
+- Esegui `git tag v1.0.0 && git push origin v1.0.0` per generare una nuova release.
+- In alternativa avvia manualmente il workflow **Android Release** dalla sezione *Actions*.
+- Il file APK prodotto è allegato come artefatto e alla release GitHub.
+


### PR DESCRIPTION
## Summary
- add Android Release workflow to build and publish APK with GitHub Actions
- document how to trigger release workflow in README

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a06dd08b988321a0f74f6f363589df