### PR TITLE
security: harden Android app backup settings after security review

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
### Motivation
- Reduce risk of local/ADB/cloud data exfiltration by removing an app-level setting that allowed full backups.  
- Perform a focused post-update security review across mobile manifests, app code, CI workflows and dependency checks to identify immediate, low-risk mitigations.  

### Description
- In `android/app/src/main/AndroidManifest.xml` set `android:allowBackup="false"` and added `android:fullBackupContent="false"` to disable device/cloud backups.  
- Performed static scans and manual inspection of key files (`src/components/ui/chart.tsx`, `src/components/ui/sidebar.tsx`, `ios/App/App/Info.plist`, `.github/workflows/android-release.yml`, `package.json`) and found no hardcoded secrets and only a template-level `dangerouslySetInnerHTML` usage in the chart component.  
- No other code or CI workflow changes were made in this PR to keep the change minimal and low-risk.  

### Testing
- `pnpm install --frozen-lockfile` executed successfully.  
- `pnpm lint` completed with warnings only (no errors).  
- `pnpm build` completed successfully and produced the production build.  
- Registry-backed audits were not possible in this environment: `pnpm audit --json` and `npx --yes osv-scanner --lockfile=pnpm-lock.yaml` failed with `403 Forbidden`, and `npm audit --json` failed with `ENOLOCK` because there is no `package-lock.json` in this pnpm-managed project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e2c89c3888321a96c86cf8e737cb9)